### PR TITLE
Update governance doc

### DIFF
--- a/example_governance_doc.md
+++ b/example_governance_doc.md
@@ -49,15 +49,15 @@ The following is a proposed learning path for contributors not familiar with Apo
 
 ### Learning Paths
 
-Apollo offers two certification courses through their Odyssey platform: [Associate](https://www.apollographql.com/tutorials/certifications/apollo-graph-associate) and [Professional](https://www.apollographql.com/tutorials/certifications/apollo-graph-professional). Contributors are recommended to complete at least the Associate certification in order to understand the basics of GraphQL and Federation.
+Apollo offers two certifications through their Odyssey platform: [Associate](https://www.apollographql.com/tutorials/certifications/apollo-graph-associate) and [Professional](https://www.apollographql.com/tutorials/certifications/apollo-graph-professional). Contributors are recommended to complete at least the Associate certification in order to understand the basics of GraphQL and Federation.
+
+Contributors working on REST connectors are recommended to complete the [Apollo Orchestration Associate](https://www.apollographql.com/tutorials/certifications/apollo-orchestration-associate) certification as well.
 
 In addition to the certifications, Apollo also offers smaller courses for focusing on certain areas:
 
 - [A bite-sized course on what federation is](https://www.apollographql.com/tutorials/introduction-to-federation)
-- [Basics of GraphOS with a strong focus on Studio usage](https://www.apollographql.com/tutorials/getting-started-with-graphos)
-- [Course on safe API delivery into GraphOS](https://www.apollographql.com/tutorials/graphos-shipping-supergraph)
-- [Mini-course on growing your supergraph](https://www.apollographql.com/tutorials/graphos-growing-supergraph)
-- [Course around leveraging Apollo Client on a React front-end](https://www.apollographql.com/tutorials/client-side-graphql-react)
+- [Set of courses on working with your supergraph](https://www.apollographql.com/tutorials/browse?categories=supergraph)
+- [Courses around leveraging Apollo Client on the front-end](https://www.apollographql.com/tutorials/browse?categories=client&paths=frontend)
 
 ### Enterprise Courses
 
@@ -66,10 +66,13 @@ Enterprise courses require ACME contributors to log into Odyssey using their SSO
 - [Observability in GraphOS](https://www.apollographql.com/tutorials/supergraph-observability)
 - [Testing for both clients and the servers](https://www.apollographql.com/tutorials/testing)
 
+A full list of Enterprise courses can be found [here](https://www.apollographql.com/tutorials/browse/?categories=enterprise)
+
 ### Additional Resources
 
-- Another great reference for GraphQL is the official [GraphQL website](https://graphql.org/learn/)
+- Another great reference for GraphQL is the [GraphQL website](https://graphql.com/learn/)
 - Teams are also encouraged to run through [Supergraph Architecture Framework (SAF) assessment](https://saf.apollographql.com/) to better understand their GraphQL posture across several pillars like Reliability, Security, Operational Excellence, Performance and Developer Experience
+- A full reference of the [GraphQL spec](https://spec.graphql.org/)
 
 ## Background
 

--- a/example_governance_doc.md
+++ b/example_governance_doc.md
@@ -55,9 +55,9 @@ In addition to the certifications, Apollo also offers smaller modules for focusi
 
 - [A bite-sized course on what federation is](https://www.apollographql.com/tutorials/introduction-to-federation)
 - [Basics of GraphOS with a strong focus on Studio usage](https://www.apollographql.com/tutorials/getting-started-with-graphos)
-- [Beta course for safe API delivery into GraphOS](https://www.apollographql.com/tutorials/graphos-shipping-supergraph)
-- [Beta mini-course on growing your supergraph](https://www.apollographql.com/tutorials/graphos-growing-supergraph)
-- [Beta course around leveraging Apollo Client on a React front-end](https://www.apollographql.com/tutorials/client-side-graphql-react)
+- [Course on safe API delivery into GraphOS](https://www.apollographql.com/tutorials/graphos-shipping-supergraph)
+- [Mini-course on growing your supergraph](https://www.apollographql.com/tutorials/graphos-growing-supergraph)
+- [Course around leveraging Apollo Client on a React front-end](https://www.apollographql.com/tutorials/client-side-graphql-react)
 
 ### Enterprise Modules
 
@@ -91,7 +91,7 @@ The success outcomes for the mission established by ACME are as follows:
 
 1. We will simplify the API landscape by making the GraphQL supergraph the preferred platform over continued development of RESTful APIs. 
 2. Our focus will be on building reusable Domain APIs to focus on reusability, maintainability and scalability while minimizing the timelines required to update business logic.
-3. We will also establish a "GraphQL Shepherds" guild to play a key role in training and up-leveling GraphQL expertise across the dev teams.
+3. We will also establish a "GraphQL Shepherds" group to play a key role in training and up-leveling GraphQL expertise across the dev teams.
 4. This, in turn will help to spread GraphQL expertise across the organization
 
 ## Procedures
@@ -140,7 +140,7 @@ For new subgraphs, there will also be a separate meeting to discuss the proposal
 
 Once both the SWG and subgraph team(s) agree on the change, the proposal will be considered "approved" and will move to be implemented into the supergraph.
 
-Subgraph teams can pull down the approved proposal using `rover` and once published to the supergraph the proposal will be marked as "implemented"
+Subgraph teams can pull down the approved proposal using `rover` and once published to the supergraph the proposal will be marked as "implemented". Subgraph teams should follow the proposed workflow outlined [here](https://www.apollographql.com/docs/graphos/platform/schema-management/proposals/implement).
 
 ### Deprecations
 

--- a/example_governance_doc.md
+++ b/example_governance_doc.md
@@ -51,7 +51,7 @@ The following is a proposed learning path for contributors not familiar with Apo
 
 Apollo offers two certification courses through their Odyssey platform: [Associate](https://www.apollographql.com/tutorials/certifications/apollo-graph-associate) and [Professional](https://www.apollographql.com/tutorials/certifications/apollo-graph-professional). Contributors are recommended to complete at least the Associate certification in order to understand the basics of GraphQL and Federation.
 
-In addition to the certifications, Apollo also offers smaller modules for focusing on certain areas:
+In addition to the certifications, Apollo also offers smaller courses for focusing on certain areas:
 
 - [A bite-sized course on what federation is](https://www.apollographql.com/tutorials/introduction-to-federation)
 - [Basics of GraphOS with a strong focus on Studio usage](https://www.apollographql.com/tutorials/getting-started-with-graphos)
@@ -59,9 +59,9 @@ In addition to the certifications, Apollo also offers smaller modules for focusi
 - [Mini-course on growing your supergraph](https://www.apollographql.com/tutorials/graphos-growing-supergraph)
 - [Course around leveraging Apollo Client on a React front-end](https://www.apollographql.com/tutorials/client-side-graphql-react)
 
-### Enterprise Modules
+### Enterprise Courses
 
-Enterprise modules require ACME contributors to log into Odyssey using their SSO credentials
+Enterprise courses require ACME contributors to log into Odyssey using their SSO credentials
 - [Effective graph stewardship](https://www.apollographql.com/tutorials/effective-stewardship)
 - [Observability in GraphOS](https://www.apollographql.com/tutorials/supergraph-observability)
 - [Testing for both clients and the servers](https://www.apollographql.com/tutorials/testing)

--- a/example_governance_doc.md
+++ b/example_governance_doc.md
@@ -49,7 +49,7 @@ The following is a proposed learning path for contributors not familiar with Apo
 
 ### Learning Paths
 
-Apollo offers two certification courses through our Odyssey platform: [Associate](https://www.apollographql.com/tutorials/certifications/apollo-graph-associate) and [Professional](https://www.apollographql.com/tutorials/certifications/apollo-graph-professional). Contributers are recommended to complete at least the Associate certification in order to understand the basics of GraphQL and Federation.
+Apollo offers two certification courses through our Odyssey platform: [Associate](https://www.apollographql.com/tutorials/certifications/apollo-graph-associate) and [Professional](https://www.apollographql.com/tutorials/certifications/apollo-graph-professional). Contributors are recommended to complete at least the Associate certification in order to understand the basics of GraphQL and Federation.
 
 In addition to the certifications, Odyssey also offers smaller modules for focusing on certain areas:
 
@@ -60,7 +60,7 @@ In addition to the certifications, Odyssey also offers smaller modules for focus
 - [Beta course around leveraging Apollo Client on a React front-end](https://www.apollographql.com/tutorials/client-side-graphql-react)
 
 ### Enterprise Modules:
-Enterprise modules require ACME contributers to log into Odyssey using their SSO credentials
+Enterprise modules require ACME contributors to log into Odyssey using their SSO credentials
 - [Effective graph stewardship](https://www.apollographql.com/tutorials/effective-stewardship)
 - [Observability in GraphOS](https://www.apollographql.com/tutorials/supergraph-observability)
 - [Testing (unit and load testing on both the client and the server)](https://www.apollographql.com/tutorials/testing)
@@ -79,18 +79,18 @@ In order to accelerate development speed, we landed on using [Apollo's Federatio
 
 ### Mission and Vision
 
-ACME is looking to establish a supergraph that is the preferred development platform for the vast majority of new services. Where advantageous, ACME will simplify their architecture by retiring Restful APIs.
+ACME is looking to establish a supergraph that is the preferred development platform for all services.
 
-The goal of the ACME supergraph is to be the aggregation layer on top of the new domain APIs architecture, defining and mapping relationships in the data across bounded contexts. Their vision is that the graph will be that defined relationship across bounded contexts. This will be a multi-year journey as they have elected for an “opt-in” model for graph adoption, rather than a mandate. Key to their success will be to make the supergraph a preferred mode of development over REST BFFs. 
+The goal of the ACME supergraph is to be the aggregation layer on top of the a domain-based services architecture, defining and mapping relationships in the data across bounded contexts. Key to our success will be to make the supergraph the preferred mode of development over REST APIs as measured by the percentage of requests going to our GraphQL instance vs their REST counterparts. 
 
-The surface of the graph potentially spans each of our current Domain APIs, beginning with the four which have active development.
+The surface of the graph will span each of our current domain services, beginning with the most used domains first.
 
 The success outcomes for the mission established by ACME are as follows:
 
-1. Simplify API landscape by making the GraphQL supergraph the preferred platform over continued development of RESTful APIs. 
-2. Focus on building reusable Domain APIs to focus on reusability, maintainability and scalability while minimizing the timelines required to update business logic.
-3. Establish a "GraphQL Shepherds" guild to play a key role in training and upleveling GraphQL expertise across the dev teams.
-4. Up-level GraphQL expertise across the organization
+1. We will simplify the API landscape by making the GraphQL supergraph the preferred platform over continued development of RESTful APIs. 
+2. Our focus will be on building reusable Domain APIs to focus on reusability, maintainability and scalability while minimizing the timelines required to update business logic.
+3. We will also establish a "GraphQL Shepherds" guild to play a key role in training and up-leveling GraphQL expertise across the dev teams.
+4. This, in turn will help to spread GraphQL expertise across the organization
 
 ## Procedures
 
@@ -122,12 +122,11 @@ You should engage the SWG as early as possible if any of these match the schema 
 * Deprecations of fields or subgraphs ([see the below deprecations section](#deprecations))
 * If a review would be helpful
 
-
 #### How to Engage
 
 While schema reviews are helpful, the core graph team also realizes that meeting after meeting isn't conducive to productivity. 
 
-With that, the SWG strongly recommends schema reviews using Apollo's [schema proposals](https://www.apollographql.com/docs/graphos/platform/schema-management/proposals) feature. Managing schema changes using schema proposals enables teams to propose schema changes that are validated against our development variant, running composition, linting and schema checks on every change. 
+With that, the SWG strongly recommends schema reviews using Apollo's [schema proposals](https://www.apollographql.com/docs/graphos/platform/schema-management/proposals) feature. Managing schema changes using schema proposals enables teams to propose schema changes that are validated against our development variant, running composition, linting and schema checks on every change.
 
 To engage with the SWG, please reach out to #graphql-swg on Slack along with a link to the appropriate schema proposal. 
 
@@ -160,7 +159,7 @@ The core graph team has an established set of guidelines for contributing to the
 
 GraphQL's strengths lie in its ability to be descriptive and easy to understand. To that, we have a list of requirements to encourage a readable schema for consumers and developers alike. 
 
-[Apollo also provides recommendations which we adhere to for the most part](https://www.apollographql.com/docs/technotes/tags/schema-design), but below are specific conventions we've landed on. We do recommend reading through Apollo's recommendations as they can be a useful tool to design better schemas. Furthermore these conventions are validated using Apollo's built-in [schema linting](https://www.apollographql.com/docs/graphos/platform/schema-management/linting) which is run on every schema check.
+[Apollo also provides recommendations which we adhere to for the most part](https://www.apollographql.com/docs/technotes/tags/schema-design), but below are specific conventions we've landed on. We do recommend reading through Apollo's recommendations as they can be a useful tool to design better schemas. Furthermore, these conventions are validated using Apollo's built-in [schema linter](https://www.apollographql.com/docs/graphos/platform/schema-management/linting) which is run with every schema check.
 
 A full list of schema linter rules can be found [here](https://www.apollographql.com/docs/graphos/platform/schema-management/linting/rules)
 
@@ -200,7 +199,7 @@ enum userType {
 
 Beyond type and value names, we also enforce naming requirements on operations. 
 
-* We discourage the use of REST-style prefixes (e.g. GET, POST, PATCH)
+* We discourage the use of REST-style prefixes (e.g. `GET`, `POST`, `PATCH`)
 * Use single-purpose queries and mutations whenever possible
 
 Examples:

--- a/example_governance_doc.md
+++ b/example_governance_doc.md
@@ -43,9 +43,31 @@ These stakeholders comprise the Schema Working Group, or SWG.
 
 ## Getting Help
 
-If you're not familiar with GraphQL, please start by looking at [Apollo's Odyssey tutorials](https://apollographql.com/tutorials/) to get acquainted with the technology.
-
 To request help with the ACME graph, please reach out in #graphql in Slack. 
+
+The following is a proposed learning path for contributors not familiar with Apollo GraphQL
+
+### Learning Paths
+
+Apollo offers two certification courses through our Odyssey platform: [Associate](https://www.apollographql.com/tutorials/certifications/apollo-graph-associate) and [Professional](https://www.apollographql.com/tutorials/certifications/apollo-graph-professional). Contributers are recommended to complete at least the Associate certification in order to understand the basics of GraphQL and Federation.
+
+In addition to the certifications, Odyssey also offers smaller modules for focusing on certain areas:
+
+- [A bite-sized course on what federation is](https://www.apollographql.com/tutorials/introduction-to-federation)
+- [Basics of GraphOS with a strong focus on Studio usage](https://www.apollographql.com/tutorials/getting-started-with-graphos)
+- [Beta course for safe API delivery into GraphOS](https://www.apollographql.com/tutorials/graphos-shipping-supergraph)
+- [Beta mini-course on growing your supergraph](https://www.apollographql.com/tutorials/graphos-growing-supergraph)
+- [Beta course around leveraging Apollo Client on a React front-end](https://www.apollographql.com/tutorials/client-side-graphql-react)
+
+### Enterprise Modules:
+Enterprise modules require ACME contributers to log into Odyssey using their SSO credentials
+- [Effective graph stewardship](https://www.apollographql.com/tutorials/effective-stewardship)
+- [Observability in GraphOS](https://www.apollographql.com/tutorials/supergraph-observability)
+- [Testing (unit and load testing on both the client and the server)](https://www.apollographql.com/tutorials/testing)
+
+### Additional Resources:
+- A great reference for GraphQL is the official [GraphQL website](https://graphql.org/learn/)
+- Teams are also encouraged to run through [Supergraph Architecture Framework (SAF) assessment](https://saf.apollographql.com/) to better understand their GraphQL posture across several pillars like Reliability, Security, Operational Excellence, Performance and Developer Experience.
 
 ## Background
 
@@ -53,7 +75,23 @@ As ACME has grown over the past year, we realized that our existing REST API sol
 
 As a result, we decided on using GraphQL to power our new API in order to quickly add and change data as requirements changed. Additionally, GraphQL offered us an opportunity to enable clients to easily access the data they cared about. 
 
-In order to accelerate development speed, we landed on using [Apollo's Federation](https://www.apollographql.com/docs/federation) specification which enables portions of the overall graph to be known as "subgraphs." The overall graph is known as the supergraph. 
+In order to accelerate development speed, we landed on using [Apollo's Federation](https://www.apollographql.com/docs/federation) specification which enables portions of the overall graph to be known as "subgraphs." The overall graph is known as the supergraph. These principles are outlined in our Mission and Vision statement below:
+
+### Mission and Vision
+
+ACME is looking to establish a supergraph that is the preferred development platform for the vast majority of new services. Where advantageous, ACME will simplify their architecture by retiring Restful APIs.
+
+The goal of the ACME supergraph is to be the aggregation layer on top of the new domain APIs architecture, defining and mapping relationships in the data across bounded contexts. Their vision is that the graph will be that defined relationship across bounded contexts. This will be a multi-year journey as they have elected for an “opt-in” model for graph adoption, rather than a mandate. Key to their success will be to make the supergraph a preferred mode of development over REST BFFs. 
+
+The surface of the graph potentially spans each of our current Domain APIs, beginning with the four which have active development.
+
+The success outcomes for the mission established by ACME are as follows:
+
+1. Simplify API landscape by making the GraphQL supergraph the preferred platform over continued development of RESTful APIs. 
+2. Focus on building reusable Domain APIs to focus on reusability, maintainability and scalability while minimizing the timelines required to update business logic.
+3. Establish a "GraphQL Shepherds" guild to play a key role in training and upleveling GraphQL expertise across the dev teams.
+4. Up-level GraphQL expertise across the organization
+
 
 ## Procedures
 

--- a/example_governance_doc.md
+++ b/example_governance_doc.md
@@ -92,7 +92,6 @@ The success outcomes for the mission established by ACME are as follows:
 3. Establish a "GraphQL Shepherds" guild to play a key role in training and upleveling GraphQL expertise across the dev teams.
 4. Up-level GraphQL expertise across the organization
 
-
 ## Procedures
 
 The core graph team has a few procedures needed for the smooth operation of the graph.
@@ -128,17 +127,19 @@ You should engage the SWG as early as possible if any of these match the schema 
 
 While schema reviews are helpful, the core graph team also realizes that meeting after meeting isn't conducive to productivity. 
 
-With that, the SWG strongly recommends schema reviews whenever possibly by doing async reviews on a shared Google Doc. A template for such is [here](). This document will ask for necessary context, such as the currently proposed schema, alternative schemas, and any UI mocks if possible.
+With that, the SWG strongly recommends schema reviews using Apollo's [schema proposals](https://www.apollographql.com/docs/graphos/platform/schema-management/proposals) feature. Managing schema changes using schema proposals enables teams to propose schema changes that are validated against our development variant, running composition, linting and schema checks on every change. 
 
-To engage with the SWG, please reach out to #graphql-swg on Slack along with the above doc. 
+To engage with the SWG, please reach out to #graphql-swg on Slack along with a link to the appropriate schema proposal. 
 
 #### Next Steps
 
-Once the SWG has received the document, they will begin to provide comments and suggestions within the doc. 
+Once the SWG has received the proposal, they will begin to provide comments and suggestions within the tool. 
 
 For new subgraphs, there will also be a separate meeting to discuss the proposal in-depth and provide further feedback. 
 
-Once both the SWG and subgraph team(s) agree on the change, the proposal will be considered "approved" and will move to be implemented into the supergraph. 
+Once both the SWG and subgraph team(s) agree on the change, the proposal will be considered "approved" and will move to be implemented into the supergraph.
+
+Subgraph teams can pull down the approved proposal using `rover` and once published to the supergraph the proposal will be marked as "implemented"
 
 ### Deprecations
 
@@ -159,7 +160,9 @@ The core graph team has an established set of guidelines for contributing to the
 
 GraphQL's strengths lie in its ability to be descriptive and easy to understand. To that, we have a list of requirements to encourage a readable schema for consumers and developers alike. 
 
-[Apollo also provides recommendations which we adhere to for the most part](https://www.apollographql.com/docs/technotes/tags/schema-design), but below are specific conventions we've landed on. We do recommend reading through Apollo's recommendations as they can be a useful tool to design better schemas. 
+[Apollo also provides recommendations which we adhere to for the most part](https://www.apollographql.com/docs/technotes/tags/schema-design), but below are specific conventions we've landed on. We do recommend reading through Apollo's recommendations as they can be a useful tool to design better schemas. Furthermore these conventions are validated using Apollo's built-in [schema linting](https://www.apollographql.com/docs/graphos/platform/schema-management/linting) which is run on every schema check.
+
+A full list of schema linter rules can be found [here](https://www.apollographql.com/docs/graphos/platform/schema-management/linting/rules)
 
 #### Naming Requirements
 

--- a/example_governance_doc.md
+++ b/example_governance_doc.md
@@ -45,13 +45,13 @@ These stakeholders comprise the Schema Working Group, or SWG.
 
 To request help with the ACME graph, please reach out in #graphql in Slack. 
 
-The following is a proposed learning path for contributors not familiar with Apollo GraphQL
+The following is a proposed learning path for contributors not familiar with Apollo GraphQL.
 
 ### Learning Paths
 
-Apollo offers two certification courses through our Odyssey platform: [Associate](https://www.apollographql.com/tutorials/certifications/apollo-graph-associate) and [Professional](https://www.apollographql.com/tutorials/certifications/apollo-graph-professional). Contributors are recommended to complete at least the Associate certification in order to understand the basics of GraphQL and Federation.
+Apollo offers two certification courses through their Odyssey platform: [Associate](https://www.apollographql.com/tutorials/certifications/apollo-graph-associate) and [Professional](https://www.apollographql.com/tutorials/certifications/apollo-graph-professional). Contributors are recommended to complete at least the Associate certification in order to understand the basics of GraphQL and Federation.
 
-In addition to the certifications, Odyssey also offers smaller modules for focusing on certain areas:
+In addition to the certifications, Apollo also offers smaller modules for focusing on certain areas:
 
 - [A bite-sized course on what federation is](https://www.apollographql.com/tutorials/introduction-to-federation)
 - [Basics of GraphOS with a strong focus on Studio usage](https://www.apollographql.com/tutorials/getting-started-with-graphos)
@@ -59,15 +59,17 @@ In addition to the certifications, Odyssey also offers smaller modules for focus
 - [Beta mini-course on growing your supergraph](https://www.apollographql.com/tutorials/graphos-growing-supergraph)
 - [Beta course around leveraging Apollo Client on a React front-end](https://www.apollographql.com/tutorials/client-side-graphql-react)
 
-### Enterprise Modules:
+### Enterprise Modules
+
 Enterprise modules require ACME contributors to log into Odyssey using their SSO credentials
 - [Effective graph stewardship](https://www.apollographql.com/tutorials/effective-stewardship)
 - [Observability in GraphOS](https://www.apollographql.com/tutorials/supergraph-observability)
-- [Testing (unit and load testing on both the client and the server)](https://www.apollographql.com/tutorials/testing)
+- [Testing for both clients and the servers](https://www.apollographql.com/tutorials/testing)
 
-### Additional Resources:
-- A great reference for GraphQL is the official [GraphQL website](https://graphql.org/learn/)
-- Teams are also encouraged to run through [Supergraph Architecture Framework (SAF) assessment](https://saf.apollographql.com/) to better understand their GraphQL posture across several pillars like Reliability, Security, Operational Excellence, Performance and Developer Experience.
+### Additional Resources
+
+- Another great reference for GraphQL is the official [GraphQL website](https://graphql.org/learn/)
+- Teams are also encouraged to run through [Supergraph Architecture Framework (SAF) assessment](https://saf.apollographql.com/) to better understand their GraphQL posture across several pillars like Reliability, Security, Operational Excellence, Performance and Developer Experience
 
 ## Background
 


### PR DESCRIPTION
Added a few sections:
- Expanded the "Getting help" section with specific odyssey courses and learning paths
- Include a "mission and vision" statement to the background section
- Rework the "Schema Reviews" section to use schema proposals instead
- Minor formatting changes

Next Steps:
- Define new sections/files that cover the following:
  -  Backend Development 
  - Client Development
  - Observability
